### PR TITLE
Deprecation fixes and default behaviour

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+# Aditional disks that need to be formated and mouted.
+# See README for syntax and usage.
+disk_additional_disks: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,7 +19,7 @@
   args:
     creates: '{{ item.disk }}1'
     executable: '/bin/bash'
-  with_items: disk_additional_disks
+  with_items: '{{ disk_additional_disks }}'
   tags:
     - disk
 
@@ -29,24 +29,24 @@
     force: '{{ item.force|d(omit) }}'
     fstype: '{{ item.fstype }}'
     opts: '{{ item.fsopts|d(omit) }}'
-  with_items: disk_additional_disks
+  with_items: '{{ disk_additional_disks }}'
   tags:
     - disk
 
 - name: "Ensure the mount directory exists"
   file: >
-    path={{ item.mount }}
-    owner={{ disk_user | default('root') }}
-    group={{ disk_group | default('root') }}
-    state=directory
-  with_items: disk_additional_disks
+    path: '{{ item.mount }}'
+    owner: '{{ disk_user | default('root') }}'
+    group: '{{ disk_group | default('root') }}'
+    state: directory
+  with_items: '{{ disk_additional_disks }}'
   tags:
     - disk
 
 - name: Get UUID for partition
   command: blkid -s UUID -o value "{{ item.disk }}1"
   register: disk_blkid
-  with_items: disk_additional_disks
+  with_items: '{{ disk_additional_disks }}'
   changed_when: False
   tags:
     - disk


### PR DESCRIPTION
Role trows deprecation warnings in later versions of Ansible. 
I also think every variable deserves a default. Now the role can be included in a playbook in which not all hosts have an additional disk. Besides this way one can just glance at the defaults/main.yml and know how use the role (to really make this work you might want to put in a commented version of its syntax).
