### PR TITLE
Allow the use to choose the package manager manually

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ disk_additional_disks:
 You can add:
 * `disk_user` sets owner of the mount directory (default: root)
 * `disk_group` sets group of the mount directory (default: root)
+* `disk_package_use` is the required package manager module to use (yum, apt, etc). The default 'auto' will use existing facts or try to autodetect it.
 
 The following filesystems are currently supported:
 - [ext2](http://en.wikipedia.org/wiki/Ext2)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,3 +2,4 @@
 # Aditional disks that need to be formated and mouted.
 # See README for syntax and usage.
 disk_additional_disks: []
+disk_package_use: auto

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-# Aditional disks that need to be formated and mouted.
+# Aditional disks that need to be formated and mounted.
 # See README for syntax and usage.
 disk_additional_disks: []
 disk_package_use: auto

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,18 +17,16 @@
     creates: '{{ item.disk }}1'
     executable: '/bin/bash'
   with_items: '{{ disk_additional_disks }}'
-  tags:
-    - disk
+  tags: ['disk']
 
-- name: Create filesystem on the first partition
+- name: "Create filesystem on the first partition"
   filesystem:
     dev: '{{ item.disk }}1'
     force: '{{ item.force|d(omit) }}'
     fstype: '{{ item.fstype }}'
     opts: '{{ item.fsopts|d(omit) }}'
   with_items: '{{ disk_additional_disks }}'
-  tags:
-    - disk
+  tags: ['disk']
 
 - name: "Ensure the mount directory exists"
   file:
@@ -37,16 +35,14 @@
     group: '{{ disk_group | default("root") }}'
     state: directory
   with_items: '{{ disk_additional_disks }}'
-  tags:
-    - disk
+  tags: ['disk']
 
-- name: Get UUID for partition
+- name: "Get UUID for partition"
   command: blkid -s UUID -o value "{{ item.disk }}1"
   register: disk_blkid
   with_items: '{{ disk_additional_disks }}'
   changed_when: False
-  tags:
-    - disk
+  tags: ['disk']
 
 - name: "Mount additional disk"
   mount:
@@ -59,5 +55,4 @@
   with_together:
     - '{{ disk_additional_disks }}'
     - '{{ disk_blkid.results }}'
-  tags:
-    - disk
+  tags: ['disk']

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,13 +1,10 @@
-- name: "Install util-linux"
+- name: "Install parted"
   package:
-    name: '{{ item }}'
-    state: 'present'
-  with_flattened:
-    - 'parted'
-  tags:
-    - disk
-    - pkgs
+    name: parted
+    state: present
+    use: '{{ disk_package_use }}'
   when: disk_additional_disks
+  tags: ['disk', 'pkgs']
 
 - name: "Partition additional disks"
   shell: |


### PR DESCRIPTION
Using the `use` option of the `package` module allow to choose the package manager without relying on the facts gathering step which is slowing down the process.
