### PR TITLE
Fixing filter success

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,9 +4,19 @@
   register: __disk_config
   when: disk_discover_aws_nvme_ebs | default(True) | bool
 
-- set_fact:
-    disk_additional_disks: "{{ __disk_config['ansible_facts']['config'] }}"
-  when: __disk_config is defined and __disk_config | success and 'ansible_facts' in __disk_config
+- name: setting fact if ansible version is 2.5 or older
+  block:
+  - set_fact:
+      disk_additional_disks: "{{ __disk_config['ansible_facts']['config'] }}"
+    when: __disk_config is defined and __disk_config | success and 'ansible_facts' in __disk_config
+  when: ansible_version.full is version('2.5.0', '<=')
+
+- name: setting fact if ansible version is newer than 2.5
+  block:
+  - set_fact:
+      disk_additional_disks: "{{ __disk_config['ansible_facts']['config'] }}"
+    when: __disk_config is defined and __disk_config is not successful and 'ansible_facts' in __disk_config
+  when: ansible_version.full is version('2.5.0', '>')
 
 - name: "Install parted"
   package:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,14 +9,14 @@
   - set_fact:
       disk_additional_disks: "{{ __disk_config['ansible_facts']['config'] }}"
     when: __disk_config is defined and __disk_config | success and 'ansible_facts' in __disk_config
-  when: ansible_version.full is version('2.5.0', '<=')
+  when: ansible_version.full is version('2.5.0', '<')
 
 - name: setting fact if ansible version is newer than 2.5
   block:
   - set_fact:
       disk_additional_disks: "{{ __disk_config['ansible_facts']['config'] }}"
     when: __disk_config is defined and __disk_config is not successful and 'ansible_facts' in __disk_config
-  when: ansible_version.full is version('2.5.0', '>')
+  when: ansible_version.full is version('2.5.0', '>=')
 
 - name: "Install parted"
   package:


### PR DESCRIPTION
In ansible 2.5 the behaviour of the filter success changed (see [Porting Guide](https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_2.5.html)).

This change adds the correct filter according to the ansible version.