### PR TITLE
allow to use the role without partitioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ disk_additional_disks:
 ```
 
 * `disk` is the device, you want to mount.
-* `part` is the first partition name. If not specified, `1` will be appended to the disk name.
+* `part` is the first partition name. If not specified and partitioning is enabled, `1` will be appended to the disk name.
 * `fstype` allows you to choose the filesystem to use with the new disk.
 * `mount_options` allows you to specify custom mount options.
 * `mount` is the directory where the new disk should be mounted.
@@ -47,6 +47,7 @@ disk_additional_disks:
 
 You can add:
 * `disk_package_use` is the required package manager module to use (yum, apt, etc). The default 'auto' will use existing facts or try to autodetect it.
+* `disk_enable_partioning: false` to optionnaly disable partitioning
 
 The following filesystems are currently supported:
 - [ext2](http://en.wikipedia.org/wiki/Ext2)
@@ -69,4 +70,4 @@ How it works
 
 It uses `sfdisk` to partition the disk with a single primary partition spanning the entire disk.
 The specified filesystem will then be created with `mkfs`.
-Finally the new partition will be mounted to the specified mount path.
+Finally the new filesystem will be mounted to the specified mount path.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ disk_additional_disks:
 
 You can add:
 * `disk_package_use` is the required package manager module to use (yum, apt, etc). The default 'auto' will use existing facts or try to autodetect it.
-* `disk_enable_partioning: false` to optionnaly disable partitioning
+* `disk_enable_partioning: false` to disable partitioning
 
 The following filesystems are currently supported:
 - [ext2](http://en.wikipedia.org/wiki/Ext2)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,4 +3,5 @@
 # See README for syntax and usage.
 disk_additional_disks: []
 disk_package_use: auto
+disk_enable_partitioning: true
 additional_fs_utils: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,7 +23,7 @@
     name: parted
     state: present
     use: '{{ disk_package_use }}'
-  when: disk_additional_disks
+  when: disk_additional_disks and disk_enable_partitioning
   tags: ['disk', 'pkgs']
 
 - name: "Install additional fs progs"
@@ -47,6 +47,7 @@
     creates: '{{ item.part | default(item.disk + "1") }}'
     executable: '/bin/bash'
   with_items: '{{ disk_additional_disks }}'
+  when: disk_enable_partitioning
   register: disk_offset
   tags: ['disk']
 
@@ -61,11 +62,13 @@
     creates: '{{ item.part | default(item.disk + "1") }}'
     executable: '/bin/bash'
   with_items: '{{ disk_additional_disks }}'
+  when: disk_enable_partitioning
   tags: ['disk']
 
-- name: "Create filesystem on the first partition"
+- name: "Create filesystem on the volume"
   filesystem:
-    dev: '{{ item.part | default(item.disk + "1") }}'
+    #dev: '{{ item.part | default(item.disk + "1") }}'
+    dev: '{{ (disk_enable_partitioning == true) | ternary(item.part | default(item.disk + "1"), item.disk) }}'
     force: '{{ item.force|d(omit) }}'
     fstype: '{{ item.fstype }}'
     opts: '{{ item.fsopts|d(omit) }}'
@@ -73,7 +76,7 @@
   tags: ['disk']
 
 - name: "Disable periodic fsck on ext3 or ext4 formatted disks"
-  shell: tune2fs -c0 -i0 {{ item.part | default(item.disk + "1") }}
+  shell: 'tune2fs -c0 -i0 {{ (disk_enable_partitioning == true) | ternary(item.part | default(item.disk + "1"), item.disk) }}'
   with_items: '{{ disk_additional_disks }}'
   when: "disk_additional_disks and ( item.fstype == 'ext4' or item.fstype == 'ext3' ) and item.disable_periodic_fsck|default(false)|bool"
   tags: ['disk']
@@ -87,8 +90,8 @@
   with_items: '{{ disk_additional_disks }}'
   tags: ['disk']
 
-- name: "Get UUID for partition"
-  command: blkid -s UUID -o value {{ item.part | default(item.disk + "1") }}
+- name: "Get UUID for volume"
+  command: 'blkid -s UUID -o value {{ (disk_enable_partitioning == true) | ternary(item.part | default(item.disk + "1"), item.disk) }}'
   register: disk_blkid
   with_items: '{{ disk_additional_disks }}'
   changed_when: False

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -67,7 +67,6 @@
 
 - name: "Create filesystem on the volume"
   filesystem:
-    #dev: '{{ item.part | default(item.disk + "1") }}'
     dev: '{{ (disk_enable_partitioning == true) | ternary(item.part | default(item.disk + "1"), item.disk) }}'
     force: '{{ item.force|d(omit) }}'
     fstype: '{{ item.fstype }}'


### PR DESCRIPTION
Because we don't need partitioning on our additional disks, we made some changes to the role.

We added a new variable `disk_enable_partitioning` set to true by default, so that the behaviour of the role will be the same as before when an item in the list has no `part` defined (ie, a partition will be created anyway).